### PR TITLE
feat: inject `env` into ejs template by default

### DIFF
--- a/workspaces/example/.env.development
+++ b/workspaces/example/.env.development
@@ -1,0 +1,3 @@
+NODE_ENV=development
+
+VITE_TEST=foobar

--- a/workspaces/example/index.html
+++ b/workspaces/example/index.html
@@ -8,6 +8,5 @@
   <body>
     <div id="root"></div>
     <div>VITE_TEST: <%= VITE_TEST %></div>
-    <div>__APP_VERSION__: <%= __APP_VERSION__ %></div>
   </body>
 </html>

--- a/workspaces/example/index.html
+++ b/workspaces/example/index.html
@@ -7,5 +7,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <div>VITE_TEST: <%= VITE_TEST %></div>
+    <div>__APP_VERSION__: <%= __APP_VERSION__ %></div>
   </body>
 </html>

--- a/workspaces/example/vite.config.ts
+++ b/workspaces/example/vite.config.ts
@@ -8,6 +8,9 @@ const base = '/'; // You can change whatever you want
 // https://vitejs.dev/config/
 export default defineConfig({
   base,
+  define: {
+    __APP_VERSION__: '1.0',
+  },
   plugins: [
     vue(),
     vueJsx(),

--- a/workspaces/example/vite.config.ts
+++ b/workspaces/example/vite.config.ts
@@ -8,9 +8,6 @@ const base = '/'; // You can change whatever you want
 // https://vitejs.dev/config/
 export default defineConfig({
   base,
-  define: {
-    __APP_VERSION__: '1.0',
-  },
   plugins: [
     vue(),
     vueJsx(),

--- a/workspaces/plugin/src/plugin.ts
+++ b/workspaces/plugin/src/plugin.ts
@@ -4,7 +4,7 @@ import color from 'cli-color';
 import { readFileSync } from 'fs';
 import history from 'connect-history-api-fallback';
 import { name as pkgName } from '../package.json';
-import { Plugin, normalizePath, createFilter, loadEnv } from 'vite';
+import { Plugin, normalizePath, createFilter } from 'vite';
 import type { ResolvedConfig } from 'vite';
 import { MpaOptions, AllowedEvent, Page, WatchOptions } from './api-types';
 
@@ -28,7 +28,6 @@ export function createMpaPlugin<
     rewrites,
     watchOptions,
   } = config;
-  let env: Record<string, string>;
   let resolvedConfig: ResolvedConfig;
 
   type CommonPage = Page<string, string, string>;
@@ -78,7 +77,7 @@ export function createMpaPlugin<
           )}"></script>\n</body>`,
         ),
       {
-        ...env,
+        ...resolvedConfig.env,
         ...resolvedConfig.define,
         ...page.data,
       },
@@ -87,8 +86,7 @@ export function createMpaPlugin<
 
   return {
     name: pluginName,
-    config(userConfig, { mode }) {
-      env = loadEnv(mode, process.cwd());
+    config() {
       configInit(config.pages); // 初始化
 
       return {

--- a/workspaces/plugin/src/plugin.ts
+++ b/workspaces/plugin/src/plugin.ts
@@ -78,7 +78,6 @@ export function createMpaPlugin<
         ),
       {
         ...resolvedConfig.env,
-        ...resolvedConfig.define,
         ...page.data,
       },
     );


### PR DESCRIPTION
默认向 ejs 模板中注入 `env`  和 `define`，将获得以下收益：

* 避免在 `Page.data` 中重复配置 `env` 数据
* `vite define` 配置将在模板文件中可用

注入优先级：
```
{
  ...resolvedConfig.env,
  ...resolvedConfig.define,
  ...page.data,
}
```