### PR TITLE
fix: Vite 5 - The CJS build of Vite's Node API is deprecated

### DIFF
--- a/workspaces/plugin/package.json
+++ b/workspaces/plugin/package.json
@@ -6,6 +6,12 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
   "description": "Out-of-box MPA plugin for Vite, with html template engine and virtual files support.",
   "homepage": "https://github.com/emosheeep/vite-plugin-virtual-mpa/tree/master/workspaces/plugin#readme",
   "repository": {


### PR DESCRIPTION
The CJS build of Vite's Node API is deprecated.

```
Trace: The CJS build of Vite's Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.
    at warnCjsUsage (<path>/node_modules/vite/index.cjs:32:3)
    at Object.<anonymous> (<path>/node_modules/vite/index.cjs:3:1)
    at Module._compile (node:internal/modules/cjs/loader:1376:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1435:10)
    at Module.load (node:internal/modules/cjs/loader:1207:32)
    at Module._load (node:internal/modules/cjs/loader:1023:12)
    at Module.require (node:internal/modules/cjs/loader:1235:19)
    at require (node:internal/modules/helpers:176:18)
    at Object.<anonymous> (<path>/node_modules/vite-plugin-virtual-mpa/dist/index.js:89:19)
    at Module._compile (node:internal/modules/cjs/loader:1376:14)

```