### PR TITLE
Support configuring response headers for development environment server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # vite-plugin-virtual-mpa
 
+## 1.11.0
+
+### Minor Changes
+
+- feat: Support configuring response headers for development environment server
+
 ## 1.10.1
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-virtual-mpa",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "author": "秦旭洋 <emosheep@qq.com>",
   "license": "MIT",
   "description": "Out-of-box MPA plugin for Vite, with html template engine and virtual files support.",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -313,6 +313,9 @@ export function createMpaPlugin<
           return next(); // This allows vite handling unmatched paths.
         }
 
+        Object.entries(config?.server?.headers || {}).forEach(([key, value]) => {
+          res.setHeader(key, value!);
+        });
         /**
          * The following 2 lines fixed #12.
          * When using cypress for e2e testing, we should manually set response header and status code.


### PR DESCRIPTION
背景：微前端子应用跨域配置失败
环境：
- @micro-zoe/micro-app: 1.0.0-rc.4
- vite: 3.2.5
改动：取vite.config中的server.headers设置为返回headers