### PR TITLE
Prevent the Vite dev server from crashing when rendering EJS templates fails

### DIFF
--- a/.changeset/popular-parents-rule.md
+++ b/.changeset/popular-parents-rule.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-virtual-mpa": patch
+---
+
+fix: Prevent the Vite dev server from crashing when rendering EJS templates fails

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -313,9 +313,11 @@ export function createMpaPlugin<
           return next(); // This allows vite handling unmatched paths.
         }
 
-        Object.entries(config?.server?.headers || {}).forEach(([key, value]) => {
-          res.setHeader(key, value!);
-        });
+        Object.entries(config?.server?.headers || {}).forEach(
+          ([key, value]) => {
+            res.setHeader(key, value!);
+          },
+        );
         /**
          * The following 2 lines fixed #12.
          * When using cypress for e2e testing, we should manually set response header and status code.
@@ -325,20 +327,24 @@ export function createMpaPlugin<
         res.statusCode = 200;
 
         // load file
-        const loadResult = await pluginContainer.load(
-          path.resolve(config.root, fileName),
-        );
-        if (!loadResult) {
-          throw new Error(`Failed to load url ${fileName}`);
-        }
+        try {
+          const loadResult = await pluginContainer.load(
+            path.resolve(config.root, fileName),
+          );
+          if (!loadResult) {
+            return next(new Error(`Failed to load url ${fileName}`));
+          }
 
-        res.end(
-          await transformIndexHtml(
-            url,
-            typeof loadResult === 'string' ? loadResult : loadResult.code,
-            req.originalUrl,
-          ),
-        );
+          res.end(
+            await transformIndexHtml(
+              url,
+              typeof loadResult === 'string' ? loadResult : loadResult.code,
+              req.originalUrl,
+            ),
+          );
+        } catch (e) {
+          next(e);
+        }
       });
     },
     configurePreviewServer(server) {


### PR DESCRIPTION
Before these changes, the Vite dev server would stop if rendering an EJS template caused an error:
![before](https://github.com/emosheeep/vite-plugin-virtual-mpa/assets/6833028/4ba114e3-c424-453e-a2ae-b557d34c617b)

After these changes, the rendering error is handled more gracefully - The server doesn't stop and the error is displayed in the browser. When the issue is solved, the page reloads automatically and the error overlay is cleared.
![after](https://github.com/emosheeep/vite-plugin-virtual-mpa/assets/6833028/f404702b-124e-49b4-9dbe-168de399bc40)

Changes were tested with Vite 5.2.11 and 5.3.1.